### PR TITLE
refactor(feat-H0wAway): 重构和优化了传输原因的枚举使用

### DIFF
--- a/src/main/java/com/baoyubo/business/enums/RemoteOperateTypeEnum.java
+++ b/src/main/java/com/baoyubo/business/enums/RemoteOperateTypeEnum.java
@@ -8,6 +8,7 @@ import lombok.Getter;
  * @author yubo.bao
  * @date 2023/7/3 14:09
  */
+@Getter
 public enum RemoteOperateTypeEnum {
 
     /**
@@ -51,10 +52,8 @@ public enum RemoteOperateTypeEnum {
     CLOSE("close", "连接关闭"),
     ;
 
-    @Getter
     private final String type;
 
-    @Getter
     private final String description;
 
 

--- a/src/main/java/com/baoyubo/controller/ClientController.java
+++ b/src/main/java/com/baoyubo/controller/ClientController.java
@@ -3,7 +3,9 @@ package com.baoyubo.controller;
 import com.baoyubo.business.ClientBiz;
 import com.baoyubo.business.enums.RemoteOperateTypeEnum;
 import com.baoyubo.business.model.RemoteOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,9 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 客户端 业务API
@@ -24,7 +23,7 @@ import java.util.Map;
 @RestController
 public class ClientController {
 
-    @Autowired
+    @Resource
     private ClientBiz clientBiz;
 
     /**
@@ -35,8 +34,8 @@ public class ClientController {
      */
     @RequestMapping(value = "/iec104/client/start", method = RequestMethod.POST)
     public ResponseEntity<Object> start(
-            @RequestParam(value = "remote_host") String remoteHost,
-            @RequestParam(value = "remote_port") Integer remotePort
+        @RequestParam(value = "remote_host") String remoteHost,
+        @RequestParam(value = "remote_port") Integer remotePort
     ) {
         clientBiz.startClient(remoteHost, remotePort);
         return ResponseEntity.ok().build();
@@ -66,10 +65,10 @@ public class ClientController {
             Map<Integer, Object> params = new HashMap<>();
             remoteOperation.getParams().forEach((k, v) -> {
                 if (RemoteOperateTypeEnum.REMOTE_CONTROL == remoteOperation.getOperateType()
-                        || RemoteOperateTypeEnum.GENERAL_CALL_HARUNOBU == remoteOperation.getOperateType()
-                        || RemoteOperateTypeEnum.HARUNOBU == remoteOperation.getOperateType()
+                    || RemoteOperateTypeEnum.GENERAL_CALL_HARUNOBU == remoteOperation.getOperateType()
+                    || RemoteOperateTypeEnum.HARUNOBU == remoteOperation.getOperateType()
                 ) {
-                    params.put(k, ((Integer) v));
+                    params.put(k, v);
                 } else {
                     params.put(k, ((Double) v).floatValue());
                 }

--- a/src/main/java/com/baoyubo/controller/ServerController.java
+++ b/src/main/java/com/baoyubo/controller/ServerController.java
@@ -3,7 +3,9 @@ package com.baoyubo.controller;
 import com.baoyubo.business.ServerBiz;
 import com.baoyubo.business.enums.RemoteOperateTypeEnum;
 import com.baoyubo.business.model.RemoteOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Resource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -11,9 +13,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 服务端 业务API
@@ -24,7 +23,7 @@ import java.util.Map;
 @RestController
 public class ServerController {
 
-    @Autowired
+    @Resource
     private ServerBiz serverBiz;
 
     /**
@@ -34,7 +33,7 @@ public class ServerController {
      */
     @RequestMapping(value = "/iec104/server/start", method = RequestMethod.POST)
     public ResponseEntity<Object> start(
-            @RequestParam(value = "port") Integer port
+        @RequestParam(value = "port") Integer port
     ) {
         serverBiz.startServer(port);
         return ResponseEntity.ok().build();
@@ -67,7 +66,7 @@ public class ServerController {
                         || RemoteOperateTypeEnum.GENERAL_CALL_HARUNOBU == remoteOperation.getOperateType()
                         || RemoteOperateTypeEnum.HARUNOBU == remoteOperation.getOperateType()
                 ) {
-                    params.put(k, ((Integer) v));
+                    params.put(k, (v));
                 } else {
                     params.put(k, ((Double) v).floatValue());
                 }

--- a/src/main/java/com/baoyubo/iec104/constant/Constants.java
+++ b/src/main/java/com/baoyubo/iec104/constant/Constants.java
@@ -26,27 +26,6 @@ public class Constants {
     // 信息数据-时标 字段长度
     public static final byte MESSAGE_INFO_TIME_SCALE_FIELD_LEN = 7;
 
-
-    // 传输原因 十进制 3
-    public static final short COT_3 = (short) 3;
-    // 传输原因 十进制 4
-    public static final short COT_4 = (short) 4;
-    // 传输原因 十进制 4
-    public static final short COT_5 = (short) 5;
-    // 传输原因 十进制 6
-    public static final short COT_6 = (short) 6;
-    // 传输原因 十进制 7
-    public static final short COT_7 = (short) 7;
-    // 传输原因 十进制 8
-    public static final short COT_8 = (short) 8;
-    // 传输原因 十进制 9
-    public static final short COT_9 = (short) 9;
-    // 传输原因 十进制 10
-    public static final short COT_10 = (short) 10;
-    // 传输原因 十进制 20
-    public static final short COT_20 = (short) 20;
-
-
     // 信息地址 0
     public static final int INFO_ADDRESS_0 = 0;
     // IEC104协议 默认的 公共地址

--- a/src/main/java/com/baoyubo/iec104/enums/CotEnum.java
+++ b/src/main/java/com/baoyubo/iec104/enums/CotEnum.java
@@ -1,0 +1,67 @@
+package com.baoyubo.iec104.enums;
+
+import lombok.Getter;
+
+/**
+ * IEC104协议 传送原因枚举 (Cause Of Transmission, COT, 占2个字节) 只展示常用的
+ *
+ * @author haowei.chu
+ * @date 2025年01月03日 14:27
+ */
+@Getter
+public enum CotEnum {
+    NO_USE(0x00, "未用"),
+    /**
+     * periodic, cyclic 周期、循环
+     */
+    PERIODIC(0x01, "周期、循环"),
+    /**
+     * background interrogation
+     */
+    BACK(0x02, "背景扫描"),
+    /**
+     * spontaneous 自发
+     */
+    SPONT(0x03, "突发(自发)"),
+    /**
+     * initialized 初始化完成
+     */
+    INIT(0x04, "初始化完成"),
+    /**
+     * interrogation or interrogated 请求或者被请求
+     */
+    REQ(0x05, "请求或者被请求"),
+    /**
+     * activation 激活，用于下发控制方向的遥控、参数设置
+     */
+    ACT(0x06, "激活"),
+    /**
+     * confirmation activation 激活确认，响应控制激活命令
+     */
+    ACTCON(0x07, "激活确认"),
+    /**
+     * deactivation 停止激活
+     */
+    DEACT(0x08, "停止激活"),
+    /**
+     * confirmation deactivation 停止激活确认
+     */
+    DEACTCON(0x09, "停止激活确认"),
+    /**
+     * termination activation 激活终止，用于结束控制流程，终止激活状态
+     */
+    ACTTERM(0x0a, "激活终止"),
+    FILE_TRANS(0x0d, "文件传输"),
+    /**
+     * interrogated by general interrogation 响应召唤命令
+     */
+    INTROGEN(0x14, "响应站召唤");
+
+    private final short code;
+    private final String name;
+
+    CotEnum(int code, String name) {
+        this.code = (short) code;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/baoyubo/iec104/enums/QualifiersEnum.java
+++ b/src/main/java/com/baoyubo/iec104/enums/QualifiersEnum.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * @author yubo.bao
  * @date 2023/7/3 15:08
  */
+@Getter
 public enum QualifiersEnum {
 
     /**
@@ -25,10 +26,8 @@ public enum QualifiersEnum {
     ;
 
 
-    @Getter
     private final byte value;
 
-    @Getter
     private final byte valueHex;
 
 

--- a/src/main/java/com/baoyubo/iec104/enums/TypeIdentifierEnum.java
+++ b/src/main/java/com/baoyubo/iec104/enums/TypeIdentifierEnum.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * @author yubo.bao
  * @date 2023/7/3 14:09
  */
+@Getter
 public enum TypeIdentifierEnum {
 
     /**
@@ -74,13 +75,10 @@ public enum TypeIdentifierEnum {
     TWO_POINT_REMOTE_CONTROL(46, 0x2E, 1),
     ;
 
-    @Getter
     private final byte value;
 
-    @Getter
     private final byte valueHex;
 
-    @Getter
     private final int messageInfoValueLength;
 
     /**

--- a/src/main/java/com/baoyubo/iec104/enums/UControlEnum.java
+++ b/src/main/java/com/baoyubo/iec104/enums/UControlEnum.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * @author yubo.bao
  * @date 2023/7/3 14:29
  */
+@Getter
 public enum UControlEnum {
 
     /**
@@ -45,7 +46,6 @@ public enum UControlEnum {
     ;
 
 
-    @Getter
     private final byte[] controlBytes;
 
     UControlEnum(byte[] controlBytes) {

--- a/src/main/java/com/baoyubo/iec104/factory/MessageFactory.java
+++ b/src/main/java/com/baoyubo/iec104/factory/MessageFactory.java
@@ -1,5 +1,13 @@
 package com.baoyubo.iec104.factory;
 
+import static com.baoyubo.iec104.enums.CotEnum.ACT;
+import static com.baoyubo.iec104.enums.CotEnum.ACTCON;
+import static com.baoyubo.iec104.enums.CotEnum.ACTTERM;
+import static com.baoyubo.iec104.enums.CotEnum.INIT;
+import static com.baoyubo.iec104.enums.CotEnum.INTROGEN;
+import static com.baoyubo.iec104.enums.CotEnum.REQ;
+import static com.baoyubo.iec104.enums.CotEnum.SPONT;
+
 import com.baoyubo.business.enums.RemoteOperateTypeEnum;
 import com.baoyubo.business.model.RemoteOperation;
 import com.baoyubo.iec104.constant.Constants;
@@ -131,16 +139,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.INIT_END);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_4);
+        asdu.setTransferReason(INIT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -158,16 +161,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.GENERAL_CALL);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_6);
+        asdu.setTransferReason(ACT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -185,16 +183,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.GENERAL_CALL);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_7);
+        asdu.setTransferReason(ACTCON.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -219,16 +212,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.ONE_POINT_HARUNOBU);
         asdu.setVsq(new MessageVSQ(false, messageInfoList.size()));
-        asdu.setTransferReason(isGeneralCall ? Constants.COT_20 : Constants.COT_3);
+        asdu.setTransferReason(isGeneralCall ? INTROGEN.getCode() : SPONT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(messageInfoList);
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -254,16 +242,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.SHORT_FLOAT_POINT_TELEMETRY);
         asdu.setVsq(new MessageVSQ(false, messageInfoList.size()));
-        asdu.setTransferReason(isGeneralCall ? Constants.COT_20 : Constants.COT_3);
+        asdu.setTransferReason(isGeneralCall ? INTROGEN.getCode() : SPONT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(messageInfoList);
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -281,15 +264,18 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.GENERAL_CALL);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_10);
+        asdu.setTransferReason(ACTTERM.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
+        return getIFrameMessage(asdu);
+    }
+
+    private static Message getIFrameMessage(MessageASDU asdu) {
         Message message = new Message();
         message.setFrameType(FrameTypeEnum.I_FRAME);
         message.setControl(null);
         message.setAsdu(asdu);
-
         return message;
     }
 
@@ -308,16 +294,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.TIME_SYNCHRONIZATION);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_6);
+        asdu.setTransferReason(ACT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -335,25 +316,20 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.TIME_SYNCHRONIZATION);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_7);
+        asdu.setTransferReason(ACTCON.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
     /**
-     * 客户端 时钟读取-命令 (I帧)
+     * 客户端/服务端 时钟读取-命令 (I帧)
      *
      * @return IEC104协议消息
      */
-    public static Message buildClientTimeReadMessage(Date date) {
+    public static Message buildTimeReadMessage(Date date) {
 
         MessageInfo messageInfo = new MessageInfo();
         messageInfo.setInfoAddress(Constants.INFO_ADDRESS_0);
@@ -362,45 +338,12 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.TIME_SYNCHRONIZATION);
         asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_5);
+        asdu.setTransferReason(REQ.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(Collections.singletonList(messageInfo));
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
-
-
-    /**
-     * 服务端 时钟读取-确认 (I帧)
-     *
-     * @return IEC104协议消息
-     */
-    public static Message buildServerTimeReadReplyMessage(Date date) {
-
-        MessageInfo messageInfo = new MessageInfo();
-        messageInfo.setInfoAddress(Constants.INFO_ADDRESS_0);
-        messageInfo.setTimeScale(date);
-
-        MessageASDU asdu = new MessageASDU();
-        asdu.setTypeIdentifier(TypeIdentifierEnum.TIME_SYNCHRONIZATION);
-        asdu.setVsq(new MessageVSQ(false, 1));
-        asdu.setTransferReason(Constants.COT_5);
-        asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
-        asdu.setMessageInfoList(Collections.singletonList(messageInfo));
-
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
-    }
-
 
     /**
      * 客户端 遥控选择-命令 (I帧)
@@ -430,16 +373,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(TypeIdentifierEnum.TWO_POINT_REMOTE_CONTROL);
         asdu.setVsq(new MessageVSQ(false, messageInfoList.size()));
-        asdu.setTransferReason(Constants.COT_6);
+        asdu.setTransferReason(ACT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(messageInfoList);
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -455,16 +393,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(receivedMessage.getAsdu().getTypeIdentifier());
         asdu.setVsq(receivedMessage.getAsdu().getVsq());
-        asdu.setTransferReason(Constants.COT_7);
+        asdu.setTransferReason(ACTCON.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(receivedMessage.getAsdu().getMessageInfoList());
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -482,7 +415,7 @@ public final class MessageFactory {
             byte receivedDCO = receivedMessageInfo.getInfoValue()[0];
 
             int[] res = Iec104ByteUtil.parseRemoteControlValueDCO(receivedDCO);
-            int se = res[0];
+            // int se = res[0];
             int qu = res[1];
             int scs = res[2];
 
@@ -497,16 +430,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(receivedMessage.getAsdu().getTypeIdentifier());
         asdu.setVsq(receivedMessage.getAsdu().getVsq());
-        asdu.setTransferReason(Constants.COT_6);
+        asdu.setTransferReason(ACT.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(messageInfoList);
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 
@@ -519,19 +447,7 @@ public final class MessageFactory {
     public static Message buildServerRemoteControlExecuteReplyMessage(Message receivedMessage) {
 
         // 更新 接收到的消息-传输原因字段
-        MessageASDU asdu = new MessageASDU();
-        asdu.setTypeIdentifier(receivedMessage.getAsdu().getTypeIdentifier());
-        asdu.setVsq(receivedMessage.getAsdu().getVsq());
-        asdu.setTransferReason(Constants.COT_7);
-        asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
-        asdu.setMessageInfoList(receivedMessage.getAsdu().getMessageInfoList());
-
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return buildServerRemoteControlSelectReplyMessage(receivedMessage);
     }
 
 
@@ -547,16 +463,11 @@ public final class MessageFactory {
         MessageASDU asdu = new MessageASDU();
         asdu.setTypeIdentifier(receivedMessage.getAsdu().getTypeIdentifier());
         asdu.setVsq(receivedMessage.getAsdu().getVsq());
-        asdu.setTransferReason(Constants.COT_10);
+        asdu.setTransferReason(ACTTERM.getCode());
         asdu.setCommonAddress(Constants.DEFAULT_COMMON_ADDRESS);
         asdu.setMessageInfoList(receivedMessage.getAsdu().getMessageInfoList());
 
-        Message message = new Message();
-        message.setFrameType(FrameTypeEnum.I_FRAME);
-        message.setControl(null);
-        message.setAsdu(asdu);
-
-        return message;
+        return getIFrameMessage(asdu);
     }
 
 

--- a/src/main/java/com/baoyubo/iec104/handler/ClientDataHandler.java
+++ b/src/main/java/com/baoyubo/iec104/handler/ClientDataHandler.java
@@ -1,6 +1,13 @@
 package com.baoyubo.iec104.handler;
 
 
+import static com.baoyubo.iec104.enums.CotEnum.ACTCON;
+import static com.baoyubo.iec104.enums.CotEnum.ACTTERM;
+import static com.baoyubo.iec104.enums.CotEnum.INIT;
+import static com.baoyubo.iec104.enums.CotEnum.INTROGEN;
+import static com.baoyubo.iec104.enums.CotEnum.REQ;
+import static com.baoyubo.iec104.enums.CotEnum.SPONT;
+
 import com.baoyubo.business.enums.RemoteOperateTypeEnum;
 import com.baoyubo.business.model.RemoteOperation;
 import com.baoyubo.iec104.constant.Constants;
@@ -16,12 +23,11 @@ import com.baoyubo.iec104.util.Iec104ByteUtil;
 import com.baoyubo.iec104.util.JsonUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
+import java.util.Date;
+import java.util.function.Consumer;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
-import java.util.function.Consumer;
 
 /**
  * 客户端 数据处理
@@ -61,14 +67,14 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    public void channelActive(ChannelHandlerContext ctx) {
         LOGGER.info("[客户端-建立连接] 开始自动下发 初始化-启动链路");
         Message message = MessageFactory.buildClientInitStartMessage();
         ctx.writeAndFlush(message);
     }
 
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    public void channelInactive(ChannelHandlerContext ctx) {
         LOGGER.info("[客户端-关闭连接]");
         // 通知客户端业务：连接关闭
         RemoteOperation remoteOperate = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.CLOSE, null);
@@ -77,7 +83,7 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
 
 
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, Message message) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, Message message) {
 
         LOGGER.debug("[客户端-收到消息-处理开始] **********  Message : {}", JsonUtil.toJsonString(message));
 
@@ -160,11 +166,10 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         TypeIdentifierEnum typeIdentifierEnum = asdu.getTypeIdentifier();
 
         // 初始化-结束
-        if (TypeIdentifierEnum.INIT_END == typeIdentifierEnum && Constants.COT_4 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.INIT_END == typeIdentifierEnum && INIT.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-初始化结束] 初始化-结束");
             return;
         }
-
 
         LOGGER.warn("[客户端-收到I帧消息-初始化结束] 不支持处理的消息");
     }
@@ -183,13 +188,14 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         QualifiersEnum qualifiersEnum = asdu.getMessageInfoList().get(0).getQualifier();
 
         // 总召唤-确认
-        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && Constants.COT_7 == asdu.getTransferReason() && QualifiersEnum.GENERAL_CALL_QUALIFIER == qualifiersEnum) {
+        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && ACTCON.getCode() == asdu.getTransferReason()
+            && QualifiersEnum.GENERAL_CALL_QUALIFIER == qualifiersEnum) {
             LOGGER.info("[客户端-收到I帧消息-总召唤] 总召唤-确认");
             return;
         }
 
         // 总召唤-结束
-        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && Constants.COT_10 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && ACTTERM.getCode() == asdu.getTransferReason()) {
             // 通知客户端业务：总召唤结束
             RemoteOperation remoteOperation = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.GENERAL_CALL_END, message);
             bizDataConsumer.accept(remoteOperation);
@@ -216,15 +222,15 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         TypeIdentifierEnum typeIdentifierEnum = asdu.getTypeIdentifier();
 
         // 时钟同步-确认
-        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && Constants.COT_7 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && ACTCON.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-时钟同步] 时钟同步-确认, 开始下发 时钟读取-命令");
-            Message newMessage = MessageFactory.buildClientTimeReadMessage(new Date());
+            Message newMessage = MessageFactory.buildTimeReadMessage(new Date());
             ctx.writeAndFlush(newMessage);
             return;
         }
 
         // 时钟读取-确认
-        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && Constants.COT_5 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && REQ.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-时钟同步] 时钟读取-确认");
             return;
         }
@@ -245,7 +251,7 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         TypeIdentifierEnum typeIdentifierEnum = asdu.getTypeIdentifier();
 
         // 总召唤-遥信数据
-        if (TypeIdentifierEnum.isHarunobu(typeIdentifierEnum) && Constants.COT_20 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.isHarunobu(typeIdentifierEnum) && INTROGEN.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-遥信数据] 总召唤-遥信数据");
             // 通知客户端业务：总召唤-遥信数据
             RemoteOperation remoteOperation = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.GENERAL_CALL_HARUNOBU, message);
@@ -254,7 +260,7 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         }
 
         // 遥信数据
-        if (TypeIdentifierEnum.isHarunobu(typeIdentifierEnum) && Constants.COT_3 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.isHarunobu(typeIdentifierEnum) && SPONT.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-遥信数据] 遥信数据");
             // 通知客户端业务：总召唤-遥信数据
             RemoteOperation remoteOperation = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.HARUNOBU, message);
@@ -278,7 +284,7 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         TypeIdentifierEnum typeIdentifierEnum = asdu.getTypeIdentifier();
 
         // 总召唤-遥测数据
-        if (TypeIdentifierEnum.isTelemetry(typeIdentifierEnum) && Constants.COT_20 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.isTelemetry(typeIdentifierEnum) && INTROGEN.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-遥测数据] 总召唤-遥测数据");
             // 通知客户端业务：总召唤-遥测数据
             RemoteOperation remoteOperation = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.GENERAL_CALL_TELEMETRY, message);
@@ -287,7 +293,7 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         }
 
         // 遥测数据
-        if (TypeIdentifierEnum.isTelemetry(typeIdentifierEnum) && Constants.COT_3 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.isTelemetry(typeIdentifierEnum) && SPONT.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[客户端-收到I帧消息-遥测数据] 遥测数据");
             // 通知客户端业务：遥测数据
             RemoteOperation remoteOperation = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.TELEMETRY, message);
@@ -314,11 +320,11 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         byte dco = asdu.getMessageInfoList().get(0).getInfoValue()[0];
         int[] res = Iec104ByteUtil.parseRemoteControlValueDCO(dco);
         int se = res[0];
-        int qu = res[1];
-        int scs = res[2];
+        // int qu = res[1];
+        // int scs = res[2];
 
         // 遥控选择-确认
-        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && Constants.COT_7 == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_SELECT == se) {
+        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && ACTCON.getCode() == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_SELECT == se) {
             LOGGER.info("[客户端-收到I帧消息-遥控数据] 遥控选择-确认, 开始下发 遥控执行-命令");
             Message newMessage = MessageFactory.buildClientRemoteControlExecuteMessage(message);
             ctx.writeAndFlush(newMessage);
@@ -326,13 +332,15 @@ public class ClientDataHandler extends SimpleChannelInboundHandler<Message> {
         }
 
         // 遥控执行-确认
-        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && Constants.COT_7 == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
+        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && ACTCON.getCode() == asdu.getTransferReason()
+            && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
             LOGGER.info("[客户端-收到I帧消息-遥控数据] 遥控执行-确认");
             return;
         }
 
         // 遥控执行-结束
-        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && Constants.COT_10 == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
+        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && ACTTERM.getCode() == asdu.getTransferReason()
+            && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
             LOGGER.info("[客户端-收到I帧消息-遥控数据] 遥控执行-结束");
             return;
         }

--- a/src/main/java/com/baoyubo/iec104/handler/ServerDataHandler.java
+++ b/src/main/java/com/baoyubo/iec104/handler/ServerDataHandler.java
@@ -44,7 +44,6 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
      */
     private final Consumer<RemoteOperation> bizDataConsumer;
 
-
     /**
      * 构造函数
      *
@@ -61,21 +60,26 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+    public void channelActive(ChannelHandlerContext ctx) {
         LOGGER.info("[服务端-建立连接]");
     }
 
+    /**
+     * 服务端-关闭连接
+     */
     @Override
-    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    public void channelInactive(ChannelHandlerContext ctx) {
         LOGGER.info("[服务端-关闭连接]");
         //通知服务端业：连接关闭
         RemoteOperation remoteOperate = RemoteOperationFactory.buildRemoteOperationByMessage(RemoteOperateTypeEnum.CLOSE, null);
         bizDataConsumer.accept(remoteOperate);
     }
 
-
+    /**
+     * 服务端-收到消息
+     */
     @Override
-    protected void channelRead0(ChannelHandlerContext ctx, Message message) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, Message message) {
 
         LOGGER.debug("[服务端-收到消息-处理开始] **********  Message : {}", JsonUtil.toJsonString(message));
 

--- a/src/main/java/com/baoyubo/iec104/handler/ServerDataHandler.java
+++ b/src/main/java/com/baoyubo/iec104/handler/ServerDataHandler.java
@@ -1,6 +1,9 @@
 package com.baoyubo.iec104.handler;
 
 
+import static com.baoyubo.iec104.enums.CotEnum.ACT;
+import static com.baoyubo.iec104.enums.CotEnum.REQ;
+
 import com.baoyubo.business.enums.RemoteOperateTypeEnum;
 import com.baoyubo.business.model.RemoteOperation;
 import com.baoyubo.iec104.constant.Constants;
@@ -145,7 +148,7 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
         QualifiersEnum qualifiersEnum = asdu.getMessageInfoList().get(0).getQualifier();
 
         // 总召唤-命令
-        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && Constants.COT_6 == asdu.getTransferReason() && QualifiersEnum.GENERAL_CALL_QUALIFIER == qualifiersEnum) {
+        if (TypeIdentifierEnum.GENERAL_CALL == typeIdentifierEnum && ACT.getCode() == asdu.getTransferReason() && QualifiersEnum.GENERAL_CALL_QUALIFIER == qualifiersEnum) {
             LOGGER.info("[服务端-收到I帧消息-总召唤] 总召唤-命令, 开始自动回复 总召唤-确认");
             Message newMessage = MessageFactory.buildServerGeneralCallReplyMessage();
             ctx.writeAndFlush(newMessage);
@@ -175,7 +178,7 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
         TypeIdentifierEnum typeIdentifierEnum = asdu.getTypeIdentifier();
 
         // 时钟同步-命令
-        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && Constants.COT_6 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && ACT.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[服务端-收到I帧消息-时钟同步] 时钟同步-命令, 自动回复 时钟同步-确认");
             Message newMessage = MessageFactory.buildServerTimeSyncReplyMessage(new Date());
             ctx.writeAndFlush(newMessage);
@@ -183,9 +186,9 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
         }
 
         // 时钟读取-命令
-        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && Constants.COT_5 == asdu.getTransferReason()) {
+        if (TypeIdentifierEnum.TIME_SYNCHRONIZATION == typeIdentifierEnum && REQ.getCode() == asdu.getTransferReason()) {
             LOGGER.info("[服务端-收到I帧消息-时钟同步] 时钟读取-命令，自动回复 时钟读取-确认");
-            Message newMessage = MessageFactory.buildServerTimeReadReplyMessage(new Date());
+            Message newMessage = MessageFactory.buildTimeReadMessage(new Date());
             ctx.writeAndFlush(newMessage);
             return;
         }
@@ -209,11 +212,11 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
         byte dco = asdu.getMessageInfoList().get(0).getInfoValue()[0];
         int[] res = Iec104ByteUtil.parseRemoteControlValueDCO(dco);
         int se = res[0];
-        int qu = res[1];
-        int scs = res[2];
+        // int qu = res[1];
+        // int scs = res[2];
 
         // 遥控选择-命令
-        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && Constants.COT_6 == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_SELECT == se) {
+        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && ACT.getCode() == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_SELECT == se) {
             LOGGER.info("[服务端-收到I帧消息-遥控数据] 遥控选择-命令, 自动回复 遥控选择-确认");
             Message newMessage = MessageFactory.buildServerRemoteControlSelectReplyMessage(message);
             ctx.writeAndFlush(newMessage);
@@ -221,7 +224,7 @@ public class ServerDataHandler extends SimpleChannelInboundHandler<Message> {
         }
 
         // 遥控执行-命令
-        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && Constants.COT_6 == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
+        if (TypeIdentifierEnum.isRemoteControl(typeIdentifierEnum) && ACT.getCode() == asdu.getTransferReason() && Constants.REMOTE_CONTROL_SE_EXECUTE == se) {
             LOGGER.info("[服务端-收到I帧消息-遥控数据] 遥控执行-命令, 自动回复 遥控执行-确认");
             Message newMessage = MessageFactory.buildServerRemoteControlExecuteReplyMessage(message);
             ctx.writeAndFlush(newMessage);

--- a/src/main/java/com/baoyubo/iec104/manager/CacheManager.java
+++ b/src/main/java/com/baoyubo/iec104/manager/CacheManager.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 /**
  * 消息缓存管理
- * <p>
+ * <pre>
  * 此场景有如下特种：
  * 1. 有界队列
  * 2. 先进先出(丢弃)
@@ -158,9 +158,7 @@ public class CacheManager {
         // [32765, 32766, 32767, 0, 1]   <-- 0
         List<Message> res = new ArrayList<>();
         boolean find = false;
-        Iterator<Message> iterator = cacheQueue.iterator();
-        while (iterator.hasNext()) {
-            Message message = iterator.next();
+        for (Message message : cacheQueue) {
             if (n == message.getControl().getSendSequenceNum()) {
                 find = true;
             }

--- a/src/main/java/com/baoyubo/iec104/server/Iec104ServerChannel.java
+++ b/src/main/java/com/baoyubo/iec104/server/Iec104ServerChannel.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Consumer;
+import org.springframework.lang.NonNull;
 
 /**
  * IEC104协议 服务端 Channel
@@ -71,7 +72,7 @@ public class Iec104ServerChannel implements ServerChannel {
                 .channel(NioServerSocketChannel.class)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
-                    protected void initChannel(SocketChannel ch) throws Exception {
+                    protected void initChannel(@NonNull SocketChannel ch) {
                         ch.pipeline().addLast(new LoggingHandler(LogLevel.DEBUG));
                         ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(255, 1, 1, 0, 0));
                         ch.pipeline().addLast(new LengthAndHeaderPrepender());

--- a/src/main/java/com/baoyubo/iec104/util/ByteUtil.java
+++ b/src/main/java/com/baoyubo/iec104/util/ByteUtil.java
@@ -20,10 +20,10 @@ public final class ByteUtil {
      */
     public static byte[] intToByteArray(int value) {
         return new byte[]{
-                (byte) (value & 0xFF),
-                (byte) ((value >> 8) & 0xFF),
-                (byte) ((value >> 16) & 0xFF),
-                (byte) ((value >> 24) & 0xFF)
+            (byte) (value & 0xFF),
+            (byte) ((value >> 8) & 0xFF),
+            (byte) ((value >> 16) & 0xFF),
+            (byte) ((value >> 24) & 0xFF)
         };
     }
 
@@ -36,9 +36,9 @@ public final class ByteUtil {
      */
     public static int byteArrayToInt(byte[] byteArray) {
         return (byteArray[3] << 24) |
-                ((byteArray[2] & 0xFF) << 16) |
-                ((byteArray[1] & 0xFF) << 8) |
-                (byteArray[0] & 0xFF);
+            ((byteArray[2] & 0xFF) << 16) |
+            ((byteArray[1] & 0xFF) << 8) |
+            (byteArray[0] & 0xFF);
     }
 
 
@@ -50,8 +50,8 @@ public final class ByteUtil {
      */
     public static byte[] shortToByteArray(short value) {
         return new byte[]{
-                (byte) (value & 0xFF),
-                (byte) ((value >> 8) & 0xFF)
+            (byte) (value & 0xFF),
+            (byte) ((value >> 8) & 0xFF)
         };
     }
 
@@ -64,7 +64,7 @@ public final class ByteUtil {
      */
     public static short byteArrayToShort(byte[] byteArray) {
         return (short) ((byteArray[1] << 8) |
-                (byteArray[0] & 0xFF));
+            (byteArray[0] & 0xFF));
     }
 
 
@@ -77,10 +77,10 @@ public final class ByteUtil {
     public static byte[] floatToByteArray(float value) {
         int intValue = Float.floatToIntBits(value);
         return new byte[]{
-                (byte) (intValue & 0xFF),
-                (byte) ((intValue >> 8) & 0xFF),
-                (byte) ((intValue >> 16) & 0xFF),
-                (byte) ((intValue >> 24) & 0xFF)
+            (byte) (intValue & 0xFF),
+            (byte) ((intValue >> 8) & 0xFF),
+            (byte) ((intValue >> 16) & 0xFF),
+            (byte) ((intValue >> 24) & 0xFF)
         };
     }
 
@@ -93,9 +93,9 @@ public final class ByteUtil {
      */
     public static float byteArrayToFloat(byte[] byteArray) {
         int intValue = (byteArray[3] << 24) |
-                ((byteArray[2] & 0xFF) << 16) |
-                ((byteArray[1] & 0xFF) << 8) |
-                (byteArray[0] & 0xFF);
+            ((byteArray[2] & 0xFF) << 16) |
+            ((byteArray[1] & 0xFF) << 8) |
+            (byteArray[0] & 0xFF);
         return Float.intBitsToFloat(intValue);
     }
 
@@ -117,14 +117,14 @@ public final class ByteUtil {
 
         // 默认的高位在前
         byte[] millisecondByte = new byte[]{
-                (byte) ((millisecond >> 24) & 0xFF),
-                (byte) ((millisecond >> 16) & 0xFF),
-                (byte) ((millisecond >> 8) & 0xFF),
-                (byte) (millisecond & 0xFF)
+            (byte) (0),
+            (byte) (0),
+            (byte) ((millisecond >> 8) & 0xFF),
+            (byte) (millisecond & 0xFF)
         };
 
-        bOutput.write((byte) millisecondByte[3]);
-        bOutput.write((byte) millisecondByte[2]);
+        bOutput.write(millisecondByte[3]);
+        bOutput.write(millisecondByte[2]);
 
         // 分钟 只占6个比特位 需要把前两位置为零
         bOutput.write((byte) calendar.get(Calendar.MINUTE));
@@ -163,8 +163,8 @@ public final class ByteUtil {
         int day = byteArray[4] & 0x1F;
         int hour = byteArray[3] & 0x1F;
         int minute = byteArray[2] & 0x3F;
-        int second = byteArray[1] > 0 ? byteArray[1] : (int) (byteArray[1] & 0xff);
-        int millisecond = byteArray[0] > 0 ? byteArray[0] : (int) (byteArray[0] & 0xff);
+        int second = byteArray[1] > 0 ? byteArray[1] : (byteArray[1] & 0xff);
+        int millisecond = byteArray[0] > 0 ? byteArray[0] : (byteArray[0] & 0xff);
 
         millisecond = (second << 8) + millisecond;
         second = millisecond / 1000;
@@ -195,8 +195,8 @@ public final class ByteUtil {
      */
     public static String toHexString(byte[] bytes) {
         StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < bytes.length; i++) {
-            String s = Integer.toHexString(bytes[i] & 0xFF).toUpperCase();
+        for (byte aByte : bytes) {
+            String s = Integer.toHexString(aByte & 0xFF).toUpperCase();
             if (s.length() == 1) {
                 stringBuilder.append("0");
             }
@@ -220,8 +220,8 @@ public final class ByteUtil {
      */
     public static String toBinaryString(byte[] bytes) {
         StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < bytes.length; i++) {
-            stringBuilder.append(toBinaryString(bytes[i]));
+        for (byte aByte : bytes) {
+            stringBuilder.append(toBinaryString(aByte));
             stringBuilder.append(" ");
         }
         return stringBuilder.substring(0, stringBuilder.length() - 1);

--- a/src/main/java/com/baoyubo/iec104/util/JsonUtil.java
+++ b/src/main/java/com/baoyubo/iec104/util/JsonUtil.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * JSON 工具类

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 server:
   port: 8080
-
-spring:
-  application:
-    name: pe-eco-micro
-  http:
+  servlet:
     encoding:
       force: true
       charset: UTF-8
       enabled: true
+
+spring:
+  application:
+    name: pe-eco-micro

--- a/src/test/java/com/baoyubo/iec104/factory/MessageFactoryTest.java
+++ b/src/test/java/com/baoyubo/iec104/factory/MessageFactoryTest.java
@@ -100,8 +100,8 @@ class MessageFactoryTest {
     @Test
     void buildServerCallHarunobuMessage() {
         Map<Integer, Object> params = new HashMap<>();
-        params.put(100, (int) 1);
-        params.put(200, (int) 0);
+        params.put(100, 1);
+        params.put(200, 0);
 
         Message message = MessageFactory.buildServerHarunobuMessage(true, params);
         byte[] bytes = encode(message);
@@ -160,10 +160,10 @@ class MessageFactoryTest {
     }
 
     @Test
-    void buildClientTimeReadMessage() {
+    void buildTimeReadMessage() {
         // 2023-06-01 12:12:12
         Date date = new Date(1685592732000L);
-        Message message = MessageFactory.buildClientTimeReadMessage(date);
+        Message message = MessageFactory.buildTimeReadMessage(date);
         byte[] bytes = encode(message);
         Assertions.assertEquals("00 00 00 00 67 01 05 00 00 00 00 00 00 E0 2E 0C 0C 81 06 17", ByteUtil.toHexString(bytes));
 
@@ -175,7 +175,7 @@ class MessageFactoryTest {
     void buildServerTimeReadReplyMessage() {
         // 2023-06-01 12:12:12
         Date date = new Date(1685592732000L);
-        Message message = MessageFactory.buildServerTimeReadReplyMessage(date);
+        Message message = MessageFactory.buildTimeReadMessage(date);
         byte[] bytes = encode(message);
         Assertions.assertEquals("00 00 00 00 67 01 05 00 00 00 00 00 00 E0 2E 0C 0C 81 06 17", ByteUtil.toHexString(bytes));
 


### PR DESCRIPTION
1. 引入了CotEnum枚举类，以取代原有的常量定义，提高代码可读性和维护性;
2. 简化了MessageFactory中的代码，通过引入统一的方法来创建I帧消息;
3. 修改了QualifiersEnum和RemoteOperateTypeEnum类，去掉了多余的@Getter注解.